### PR TITLE
Add GQL fragments and fetch latest inventory in client

### DIFF
--- a/apollo/fragments/cart.ts
+++ b/apollo/fragments/cart.ts
@@ -1,0 +1,12 @@
+import { gql } from "graphql-tag";
+import { cartFields } from "~/apollo/fragments/cartFields";
+import { cartLines } from "~/apollo/fragments/cartLines";
+
+export const cart = gql`
+  ${cartFields}
+  ${cartLines}
+  fragment cart on Cart {
+    ...cartFields
+    ...cartLines
+  }
+`;

--- a/apollo/fragments/cartFields.ts
+++ b/apollo/fragments/cartFields.ts
@@ -1,0 +1,35 @@
+import { gql } from "graphql-tag";
+
+export const cartFields = gql`
+  fragment cartFields on Cart {
+    attributes {
+      key
+      value
+    }
+    checkoutUrl
+    createdAt
+    discountCodes {
+      applicable
+      code
+    }
+    estimatedCost {
+      totalAmount {
+        amount
+        currencyCode
+      }
+      subtotalAmount {
+        amount
+        currencyCode
+      }
+      totalTaxAmount {
+        amount
+        currencyCode
+      }
+      totalDutyAmount {
+        amount
+        currencyCode
+      }
+    }
+    id
+  }
+`;

--- a/apollo/fragments/cartLines.ts
+++ b/apollo/fragments/cartLines.ts
@@ -1,0 +1,68 @@
+import { gql } from "graphql-tag";
+
+export const cartLines = gql`
+  fragment cartLines on Cart {
+    lines(first: 50) {
+      edges {
+        cursor
+        node {
+          attributes {
+            key
+            value
+          }
+          discountAllocations {
+            discountedAmount {
+              amount
+              currencyCode
+            }
+          }
+          estimatedCost {
+            subtotalAmount {
+              amount
+              currencyCode
+            }
+            totalAmount {
+              amount
+              currencyCode
+            }
+          }
+          id
+          merchandise {
+            ... on ProductVariant {
+              availableForSale
+              compareAtPriceV2 {
+                amount
+                currencyCode
+              }
+              currentlyNotInStock
+              id
+              priceV2 {
+                amount
+                currencyCode
+              }
+              product {
+                handle
+                id
+                featuredImage {
+                  ... on Image {
+                    thumbnail: url(transform: { maxWidth: 160, maxHeight: 160 })
+                  }
+                  altText
+                  height
+                  width
+                }
+                tags
+                title
+              }
+              selectedOptions {
+                name
+                value
+              }
+            }
+          }
+          quantity
+        }
+      }
+    }
+  }
+`;

--- a/apollo/fragments/productVariants.ts
+++ b/apollo/fragments/productVariants.ts
@@ -1,0 +1,26 @@
+import { gql } from "graphql-tag";
+
+export const productVariants = gql`
+  fragment productVariants on Product {
+    variants(first: 100) {
+      edges {
+        cursor
+        node {
+          availableForSale
+          id
+          priceV2 {
+            amount
+            currencyCode
+          }
+          quantityAvailable
+          selectedOptions {
+            name
+            value
+          }
+          sku
+          title
+        }
+      }
+    }
+  }
+`;

--- a/apollo/mutations/cartCreate.ts
+++ b/apollo/mutations/cartCreate.ts
@@ -1,11 +1,12 @@
 import { gql } from "graphql-tag";
+import { cart } from "~/apollo/fragments/cart";
 
 export const cartCreate = gql`
+  ${cart}
   mutation cartCreate {
     cartCreate {
       cart {
-        id
-        checkoutUrl
+        ...cart
       }
       userErrors {
         code

--- a/apollo/mutations/cartLinesAdd.ts
+++ b/apollo/mutations/cartLinesAdd.ts
@@ -1,102 +1,12 @@
 import { gql } from "graphql-tag";
+import { cart } from "~/apollo/fragments/cart";
 
 export const cartLinesAdd = gql`
+  ${cart}
   mutation cartLinesAdd($lines: [CartLineInput!]!, $cartId: ID!) {
     cartLinesAdd(lines: $lines, cartId: $cartId) {
       cart {
-        attributes {
-          key
-          value
-        }
-        checkoutUrl
-        createdAt
-        discountCodes {
-          applicable
-          code
-        }
-        estimatedCost {
-          totalAmount {
-            amount
-            currencyCode
-          }
-          subtotalAmount {
-            amount
-            currencyCode
-          }
-          totalTaxAmount {
-            amount
-            currencyCode
-          }
-          totalDutyAmount {
-            amount
-            currencyCode
-          }
-        }
-        id
-        lines(first: 50) {
-          edges {
-            cursor
-            node {
-              attributes {
-                key
-                value
-              }
-              discountAllocations {
-                discountedAmount {
-                  amount
-                  currencyCode
-                }
-              }
-              estimatedCost {
-                subtotalAmount {
-                  amount
-                  currencyCode
-                }
-                totalAmount {
-                  amount
-                  currencyCode
-                }
-              }
-              id
-              merchandise {
-                ... on ProductVariant {
-                  availableForSale
-                  compareAtPriceV2 {
-                    amount
-                    currencyCode
-                  }
-                  currentlyNotInStock
-                  id
-                  priceV2 {
-                    amount
-                    currencyCode
-                  }
-                  product {
-                    handle
-                    id
-                    featuredImage {
-                      ... on Image {
-                        thumbnail: url(
-                          transform: { maxWidth: 160, maxHeight: 160 }
-                        )
-                      }
-                      altText
-                      height
-                      width
-                    }
-                    tags
-                    title
-                  }
-                  selectedOptions {
-                    name
-                    value
-                  }
-                }
-              }
-              quantity
-            }
-          }
-        }
+        ...cart
       }
       userErrors {
         code

--- a/apollo/mutations/cartLinesRemove.ts
+++ b/apollo/mutations/cartLinesRemove.ts
@@ -1,102 +1,12 @@
 import { gql } from "graphql-tag";
+import { cart } from "~/apollo/fragments/cart";
 
 export const cartLinesRemove = gql`
+  ${cart}
   mutation cartLinesRemove($cartId: ID!, $lineIds: [ID!]!) {
     cartLinesRemove(lineIds: $lineIds, cartId: $cartId) {
       cart {
-        attributes {
-          key
-          value
-        }
-        checkoutUrl
-        createdAt
-        discountCodes {
-          applicable
-          code
-        }
-        estimatedCost {
-          totalAmount {
-            amount
-            currencyCode
-          }
-          subtotalAmount {
-            amount
-            currencyCode
-          }
-          totalTaxAmount {
-            amount
-            currencyCode
-          }
-          totalDutyAmount {
-            amount
-            currencyCode
-          }
-        }
-        id
-        lines(first: 50) {
-          edges {
-            cursor
-            node {
-              attributes {
-                key
-                value
-              }
-              discountAllocations {
-                discountedAmount {
-                  amount
-                  currencyCode
-                }
-              }
-              estimatedCost {
-                subtotalAmount {
-                  amount
-                  currencyCode
-                }
-                totalAmount {
-                  amount
-                  currencyCode
-                }
-              }
-              id
-              merchandise {
-                ... on ProductVariant {
-                  availableForSale
-                  compareAtPriceV2 {
-                    amount
-                    currencyCode
-                  }
-                  currentlyNotInStock
-                  id
-                  priceV2 {
-                    amount
-                    currencyCode
-                  }
-                  product {
-                    handle
-                    id
-                    featuredImage {
-                      ... on Image {
-                        thumbnail: url(
-                          transform: { maxWidth: 160, maxHeight: 160 }
-                        )
-                      }
-                      altText
-                      height
-                      width
-                    }
-                    tags
-                    title
-                  }
-                  selectedOptions {
-                    name
-                    value
-                  }
-                }
-              }
-              quantity
-            }
-          }
-        }
+        ...cart
       }
       userErrors {
         code

--- a/apollo/queries/productByHandle.ts
+++ b/apollo/queries/productByHandle.ts
@@ -1,6 +1,8 @@
 import { gql } from "graphql-tag";
+import { productVariants } from "~/apollo/fragments/productVariants";
 
 export const productByHandle = gql`
+  ${productVariants}
   query product($handle: String!) {
     productByHandle(handle: $handle) {
       availableForSale
@@ -49,26 +51,7 @@ export const productByHandle = gql`
       productType
       tags
       title
-      variants(first: 100) {
-        edges {
-          cursor
-          node {
-            availableForSale
-            id
-            priceV2 {
-              amount
-              currencyCode
-            }
-            quantityAvailable
-            selectedOptions {
-              name
-              value
-            }
-            sku
-            title
-          }
-        }
-      }
+      ...productVariants
       vendor
     }
   }

--- a/apollo/queries/productVariantsByHandle.ts
+++ b/apollo/queries/productVariantsByHandle.ts
@@ -1,0 +1,11 @@
+import { gql } from "graphql-tag";
+import { productVariants } from "~/apollo/fragments/productVariants";
+
+export const productVariantsByHandle = gql`
+  ${productVariants}
+  query product($handle: String!) {
+    productByHandle(handle: $handle) {
+      ...productVariants
+    }
+  }
+`;

--- a/app.vue
+++ b/app.vue
@@ -21,6 +21,12 @@
 import "~/assets/css/tailwind.css";
 import { useShopStore } from "~/stores/shop";
 
+useMeta({
+  htmlAttrs: {
+    lang: "en",
+  },
+});
+
 // Global Store Actions
 const { pending, error } = await useAsyncData("shop", () => {
   const shopStore = useShopStore();

--- a/components/ProductVariants/ProductVariants.vue
+++ b/components/ProductVariants/ProductVariants.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="variants.length" class="mb-3">
+  <div v-if="variants && variants.length" class="mb-3">
     <select
       class="form-select appearance-none block w-full px-3 py-1.5 text-base font-normal bg-white bg-clip-padding bg-no-repeat border border-solid border-gray-300 focus:text-gray-700 focus:bg-white focus:border-blue-600 focus:outline-none"
       :aria-label="label"
@@ -7,7 +7,7 @@
     >
       <option selected disabled>{{ label }}</option>
       <option
-        v-for="variant: Variant in variants"
+        v-for="variant in variants"
         :key="variant.node.id"
         :disabled="!variant.node.availableForSale"
         :value="variant.node.id"
@@ -19,11 +19,12 @@
 </template>
 
 <script setup lang="ts">
+import { Ref } from "nuxt3/dist/app/compat/capi";
 import { useProductStore } from "~/stores/product";
 
 const props = defineProps<{
   label: string;
-  variants: [];
+  variants: Ref;
 }>();
 
 const { label, variants } = toRefs(props);


### PR DESCRIPTION
- Adds fragments to DRY Apollo queries/mutations
- Fetch the latest product inventory in the browser
  - This ensures that the cached values that may be on the server are not out of date